### PR TITLE
Fix the asynchronous worker timeout issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ croniter==0.3.30
 cryptography==2.7
 decorator==4.4.0          # via retry
 defusedxml==0.6.0         # via python3-openid
-flask-appbuilder==2.1.13
+flask-appbuilder==2.2.1
 flask-babel==0.12.2       # via flask-appbuilder
 flask-caching==1.7.2
 flask-compress==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "croniter>=0.3.28",
         "cryptography>=2.4.2",
         "flask>=1.1.0, <2.0.0",
-        "flask-appbuilder>=2.1.13, <2.3.0",
+        "flask-appbuilder>=2.2.0, <2.3.0",
         "flask-caching",
         "flask-compress",
         "flask-talisman",

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -111,6 +111,7 @@ from .utils import (
 
 from clickhouse_driver import Client
 import os
+from time import sleep
 
 config = app.config
 CACHE_DEFAULT_TIMEOUT = config.get("CACHE_DEFAULT_TIMEOUT", 0)
@@ -2797,6 +2798,9 @@ class Superset(BaseSupersetView):
         def generate():
             cnt = 0
             for row in rows_gen:
+                # We add sleep(0) between generator iterations to give the worker a break 
+                # to update the heartbeat file and keep the connection and worker process alive.
+                sleep(0)
                 s = ''
                 for item in row:
                     item = str(item).replace('\n', '')


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Workers silent for more than this many seconds are killed and restarted. By silent, it means silent from the perspective of the arbiter process, which communicates with the workers through a temporary file. If the worker is busy sending data, it does not update that file. From the perspective of the arbiter, the worker is missing heartbeats.

We add sleep(0) between generator iterations to give the worker a break and update the heartbeat file to keep the connection and worker process alive.